### PR TITLE
Ping flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ allprojects {
             exclude group: 'com.github.corda.crash', module: 'crash.shell'
             exclude group: 'com.github.corda.crash', module: 'crash.connectors.ssh'
             exclude group: 'com.github.bft-smart', module: 'library'
-            exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
         }
     }
 

--- a/flows/build.gradle
+++ b/flows/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     testRuntime("net.corda:corda-jackson:$corda")
     testRuntime("net.corda:corda-shell:$corda")
+    testRuntime("org.apache.logging.log4j:log4j-slf4j-impl:2.11.2")
+    testRuntime("org.slf4j:jul-to-slf4j:1.7.25")
 
     // magic dependencies
     testRuntime("org.apache.sshd:sshd-common:2.2.0")

--- a/flows/src/main/kotlin/nl/nuts/consent/flow/DiagnosticFlows.kt
+++ b/flows/src/main/kotlin/nl/nuts/consent/flow/DiagnosticFlows.kt
@@ -1,0 +1,139 @@
+/*
+ *     Nuts consent cordapp
+ *     Copyright (C) 2020 Nuts community
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package nl.nuts.consent.flow
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.internal.randomOrNull
+import net.corda.core.utilities.ProgressTracker
+import net.corda.core.utilities.unwrap
+
+/**
+ * Collection of flows for checking network health
+ */
+object DiagnosticFlows {
+
+    fun checkReceivedData(counterPartySession: FlowSession, dataToReceive: String) {
+        val packet1= counterPartySession.receive<String>()
+        val received: String = packet1.unwrap {
+            it
+        }
+
+        if (dataToReceive != received) {
+            throw FlowException("Flow returned unknown data: $received")
+        }
+    }
+
+    abstract class PingFlow : FlowLogic<Unit>() {
+
+        /**
+         * Define steps
+         */
+        companion object {
+            object FINDING_PEER : ProgressTracker.Step("Find address of peer.")
+            object SEND_DATA : ProgressTracker.Step("Sending ping.")
+            object RECEIVING_DATA : ProgressTracker.Step("Waiting for pong.")
+
+            fun tracker() = ProgressTracker(
+                    FINDING_PEER,
+                    SEND_DATA,
+                    RECEIVING_DATA
+            )
+        }
+
+        override val progressTracker: ProgressTracker = tracker()
+
+        abstract fun findTarget() : Party
+
+        @Suspendable
+        override fun call() {
+            progressTracker.currentStep = FINDING_PEER
+
+            val p = findTarget()
+
+            progressTracker.currentStep = SEND_DATA
+
+            val counterPartySession: FlowSession = initiateFlow(p)
+            counterPartySession.send("ping")
+
+            progressTracker.currentStep = RECEIVING_DATA
+
+            checkReceivedData(counterPartySession, "pong")
+        }
+    }
+
+    /**
+     * A ping flow targeted at the first Notary
+     */
+    @InitiatingFlow
+    @StartableByRPC
+    class PingNotaryFlow : PingFlow() {
+        override fun findTarget(): Party {
+            try {
+                return serviceHub.networkMapCache.notaryIdentities.first()
+            } catch (e: NoSuchElementException) {
+                throw FlowException(e)
+            }
+        }
+    }
+
+    /**
+     * A ping flow targeted at a random node
+     */
+    @InitiatingFlow
+    @StartableByRPC
+    class PingRandomFlow : PingFlow() {
+        override fun findTarget(): Party {
+            return serviceHub.networkMapCache.allNodes
+                    .map { it.legalIdentities }
+                    .toList()
+                    .flatten()
+                    .filter { serviceHub.networkMapCache.getNotary(it.name) == null }
+                    .randomOrNull() ?: throw FlowException("No nodes available")
+        }
+    }
+
+    @InitiatedBy(PingFlow::class)
+    class PongFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+        companion object {
+            object RECEIVING_DATA : ProgressTracker.Step("Waiting for ping.")
+            object SEND_DATA : ProgressTracker.Step("Sending pong.")
+
+            fun tracker() = ProgressTracker(
+                    RECEIVING_DATA,
+                    SEND_DATA
+            )
+        }
+
+        override val progressTracker: ProgressTracker = tracker()
+
+        @Suspendable
+        override fun call() {
+            progressTracker.currentStep = RECEIVING_DATA
+
+            checkReceivedData(counterPartySession, "ping")
+
+            progressTracker.currentStep = SEND_DATA
+
+            counterPartySession.send("pong")
+        }
+    }
+}

--- a/flows/src/main/kotlin/nl/nuts/consent/flow/DiagnosticFlows.kt
+++ b/flows/src/main/kotlin/nl/nuts/consent/flow/DiagnosticFlows.kt
@@ -110,11 +110,14 @@ object DiagnosticFlows {
     class PingRandomFlow : PingFlow() {
         @Suspendable
         override fun findTarget(): Party {
+            val me = serviceHub.myInfo.legalIdentities
+
             return serviceHub.networkMapCache.allNodes
                     .map { it.legalIdentities }
                     .toList()
                     .flatten()
-                    .filter { serviceHub.networkMapCache.getNotary(it.name) == null }
+                    .filter { serviceHub.networkMapCache.getNotary(it.name) == null } // no notaries
+                    .filterNot { me.contains(it) } // not myself
                     .randomOrNull() ?: throw FlowException("No nodes available")
         }
     }

--- a/flows/src/test/kotlin/nl/nuts/consent/flow/DiagnosticFlowsBrokenTest.kt
+++ b/flows/src/test/kotlin/nl/nuts/consent/flow/DiagnosticFlowsBrokenTest.kt
@@ -19,68 +19,55 @@
 
 package nl.nuts.consent.flow
 
-import com.nhaarman.mockito_kotlin.anyOrNull
-import com.nhaarman.mockito_kotlin.mock
 import net.corda.core.flows.FlowException
-import net.corda.core.flows.FlowSession
-import net.corda.core.utilities.UntrustworthyData
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.seconds
 import net.corda.testing.core.ALICE_NAME
-import net.corda.testing.core.BOB_NAME
 import net.corda.testing.node.internal.InternalMockNetwork
 import net.corda.testing.node.internal.InternalMockNodeParameters
 import net.corda.testing.node.internal.cordappWithPackages
 import net.corda.testing.node.internal.startFlow
 import org.junit.After
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
-class DiagnosticFlowsTest {
+class DiagnosticFlowsBrokenTest {
 
-    protected val network = InternalMockNetwork(cordappsForAllNodes = listOf(
-            cordappWithPackages("nl.nuts.consent.flow")
-    ))
+    protected val network = InternalMockNetwork(
+            cordappsForAllNodes = listOf(cordappWithPackages("nl.nuts.consent.flow")),
+            notarySpecs = emptyList()
+    )
 
     protected val a = network.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
-    protected val b = network.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
 
     init {
-        listOf(a, b).forEach {
-            it.registerInitiatedFlow(DiagnosticFlows.PongFlow::class.java)
-        }
+        a.registerInitiatedFlow(DiagnosticFlows.PongFlow::class.java)
     }
 
     @After
     fun tearDown() = network.stopNodes()
 
     @Test
-    fun `PingNotaryFlow succeeds`() {
+    fun `PingNotaryFlow without Notary raises`() {
         val flow = DiagnosticFlows.PingNotaryFlow()
+
         val future = a.services.startFlow(flow)
         network.runNetwork()
-        assertTrue(future.resultFuture.isDone)
-    }
-
-    @Test
-    fun `PingRandomFlow succeeds`() {
-        val flow = DiagnosticFlows.PingRandomFlow()
-        val future = a.services.startFlow(flow)
-        network.runNetwork()
-        assertTrue(future.resultFuture.isDone)
-    }
-
-    @Test
-    fun `FlowException is raised on incorrect data`() {
-        val mockSession = mock<FlowSession>()
-        val mockData = mock<UntrustworthyData<String>>()
-        `when`(mockSession.receive<String>()).thenReturn(mockData)
-        `when`(mockData.unwrap<String>(anyOrNull())).thenReturn("not pong")
 
         assertFailsWith(FlowException::class) {
-            DiagnosticFlows.checkReceivedData(mockSession, "pong")
+            future.resultFuture.getOrThrow(1.seconds)
+        }
+    }
+
+    @Test
+    fun `PingRandomFlow without peers raises`() {
+        val flow = DiagnosticFlows.PingRandomFlow()
+
+        val future = a.services.startFlow(flow)
+        network.runNetwork()
+
+        assertFailsWith(FlowException::class) {
+            future.resultFuture.getOrThrow(1.seconds)
         }
     }
 }

--- a/flows/src/test/kotlin/nl/nuts/consent/flow/DiagnosticFlowsTest.kt
+++ b/flows/src/test/kotlin/nl/nuts/consent/flow/DiagnosticFlowsTest.kt
@@ -1,0 +1,71 @@
+/*
+ *     Nuts consent cordapp
+ *     Copyright (C) 2020 Nuts community
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package nl.nuts.consent.flow
+
+import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
+import net.corda.testing.node.internal.InternalMockNetwork
+import net.corda.testing.node.internal.InternalMockNodeParameters
+import net.corda.testing.node.internal.cordappWithPackages
+import net.corda.testing.node.internal.startFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class DiagnosticFlowsTest {
+
+    protected val network = InternalMockNetwork(cordappsForAllNodes = listOf(
+            cordappWithPackages("nl.nuts.consent.flow")
+    ))
+
+    protected val a = network.createNode(InternalMockNodeParameters(legalName = ALICE_NAME))
+    protected val b = network.createNode(InternalMockNodeParameters(legalName = BOB_NAME))
+
+    init {
+        listOf(a, b).forEach {
+            it.registerInitiatedFlow(DiagnosticFlows.PongFlow::class.java)
+        }
+    }
+
+    @Before
+    open fun setup() {
+        network.runNetwork()
+    }
+
+    @After
+    fun tearDown() = network.stopNodes()
+
+    @Test
+    fun `PingNotaryFlow succeeds`() {
+        val flow = DiagnosticFlows.PingNotaryFlow()
+        val future = a.services.startFlow(flow)
+        network.runNetwork()
+        assertTrue(future.resultFuture.isDone)
+    }
+
+    @Test
+    fun `PingRandomFlow succeeds`() {
+        val flow = DiagnosticFlows.PingRandomFlow()
+        val future = a.services.startFlow(flow)
+        network.runNetwork()
+        assertTrue(future.resultFuture.isDone)
+    }
+}

--- a/flows/src/test/resources/log4j2-test.xml
+++ b/flows/src/test/resources/log4j2-test.xml
@@ -7,8 +7,11 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>
+        <Logger name="nl.nuts.consent.flow" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Added two flows for pinging the notary and a random peer node.
No states are stored, no transactions are run.

The bridge will be responsible for initiating the flows and storing the results.

Fixes #28